### PR TITLE
Enable Aptible Deployment

### DIFF
--- a/.aptible.yml
+++ b/.aptible.yml
@@ -1,2 +1,0 @@
-before_release:
-  - ./node_modules/grunt-cli/bin/grunt build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile
 FROM quay.io/aptible/autobuild
 
-RUN ./node_modules/grunt-cli/bin/grunt build
+RUN .aptible.env && ./node_modules/grunt-cli/bin/grunt build
 
 EXPOSE 2000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 # Dockerfile
 FROM quay.io/aptible/autobuild
 
+RUN ./node_modules/grunt-cli/bin/grunt build
+
 EXPOSE 2000

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM quay.io/aptible/autobuild
 
 WORKDIR /app
 
-RUN . .aptible.env && ./node_modules/grunt-cli/bin/grunt build
+RUN ./node_modules/grunt-cli/bin/grunt build
 
 EXPOSE 2000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,15 @@
 # Dockerfile
-FROM quay.io/aptible/autobuild
+FROMCACHE webapp-essential-pb-support
+FROM quay.io/aptible/webapp-essential
+
+ADD . /opt/pb-support
+WORKDIR /opt/pb-support
+
+RUN bundle install --without development test
+RUN npm install
+RUN npm install -g bower
+RUN bower cache clean --allow-root && bower install --allow-root
+RUN npm install -g grunt-cli
+RUN grunt build
 
 EXPOSE 2000

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM quay.io/aptible/autobuild
 
 WORKDIR /app
 
+env PATH /app/.heroku/node/bin:$PATH
 RUN ./node_modules/grunt-cli/bin/grunt build
 
 EXPOSE 2000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Dockerfile
 FROM quay.io/aptible/autobuild
 
-RUN .aptible.env && ./node_modules/grunt-cli/bin/grunt build
+WORKDIR /app
+
+RUN ./node_modules/grunt-cli/bin/grunt build
 
 EXPOSE 2000

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM quay.io/aptible/autobuild
 WORKDIR /app
 
 env PATH /app/.heroku/node/bin:$PATH
+env PATH /app/.heroku/ruby/bin:$PATH
 RUN ./node_modules/grunt-cli/bin/grunt build
 
 EXPOSE 2000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
 # Dockerfile
 FROM quay.io/aptible/autobuild
 
-WORKDIR /app
-
-env PATH /app/.heroku/node/bin:$PATH
-env PATH /app/.heroku/ruby/bin:$PATH
-RUN ./node_modules/grunt-cli/bin/grunt build
-
 EXPOSE 2000

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ FROM quay.io/aptible/autobuild
 
 WORKDIR /app
 
-RUN ./node_modules/grunt-cli/bin/grunt build
+RUN . .aptible.env && ./node_modules/grunt-cli/bin/grunt build
 
 EXPOSE 2000

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: grunt build && node app.js
+web: node app.js

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node app.js
+web: grunt build && node app.js


### PR DESCRIPTION
We are no longer using Aptible's `autobuild` docker image.